### PR TITLE
[BUG] 띄어쓰기로 인한 className 스타일 미반영 수정

### DIFF
--- a/src/components/layout/Button.jsx
+++ b/src/components/layout/Button.jsx
@@ -35,11 +35,11 @@ export default function Button({
       break;
     }
     case "gray": {
-      combinedClassName += "bg-gray-200 text-white font-bold rounded";
+      combinedClassName += " bg-gray-200 text-white font-bold rounded";
       break;
     }
     case "yellow": {
-      combinedClassName += "bg-yellow-100 text-white font-bold rounded";
+      combinedClassName += " bg-yellow-100 text-white font-bold rounded";
       break;
     }
     default:
@@ -49,7 +49,7 @@ export default function Button({
   // 높이
   switch (height) {
     case "xs": {
-      combinedClassName += "h-6  text-[10px]";
+      combinedClassName += " h-6  text-[10px]";
       break;
     }
     case "sm": {


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
띄어쓰기가 맞지 않아 height - xs가 미적용 됨
![image](https://github.com/user-attachments/assets/fb73c557-568f-44e1-b479-803b1a18c8d8)
![image](https://github.com/user-attachments/assets/d555bcab-9787-4fbd-ac3a-4d6a2310df43)

```js
   case "xs": {
      combinedClassName += "h-6  text-[10px]";
      break;
    }
    case "sm": {
      combinedClassName += " h-8 text-[14px]";
      break;
    }
```

위 코드에 안되어 있는 xs 띄어쓰기를 sm과 같이 수정함 

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #45 
