### PR TITLE
[FEAT] InputField 컴포넌트와 함께 react-hook-form 사용 

### DIFF
--- a/src/components/layout/InputField.jsx
+++ b/src/components/layout/InputField.jsx
@@ -8,8 +8,7 @@ InputField.propTypes = {
   errorMsg: PropTypes.string,
   isLast: PropTypes.bool,
   isTextArea: PropTypes.bool,
-  register: PropTypes.func,
-  name: PropTypes.string.isRequired,
+  register: PropTypes.func.isRequired,
 };
 
 export default function InputField({
@@ -20,7 +19,6 @@ export default function InputField({
   isLast = false,
   isTextArea = false,
   register,
-  name,
   ...props
 }) {
   // type에 따라 전달할 props 객체를 다르게 저장하는 변수
@@ -45,20 +43,20 @@ export default function InputField({
           {...dateTypeProps}
           className={`w-full p-3 border-2 border-#999 rounded-lg focus:outline-none focus:border-primary ${errorMsg ? "mb-2" : isLast ? "" : "mb-[28px]"}`}
           rows={10}
-          {...(register && register(name))}
+          {...register}
           {...props}
         />
       ) : (
         <input
           {...dateTypeProps}
           className={`w-full h-[48px] p-3 border-2 border-#999 rounded-lg focus:outline-none focus:border-primary ${errorMsg ? "mb-2" : isLast ? "" : "mb-[28px]"}`}
-          {...(register && register(name))}
+          {...register}
           {...props}
         />
       )}
       {errorMsg && (
         <p
-          className={`text-red text-xs ${isLast ? "" : "mb-2"}`}
+          className={`text-red text-xs leading-3 ${isLast ? "" : "mb-2"}`}
         >{`*${errorMsg}`}</p>
       )}
     </div>


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

InputField 컴포넌트를 사용할 때 register를 등록할 수 있게 했습니다.

**사용 방법**
1. useForm을 사용합니다.

2. 아래 코드처럼 register props에 register 함수를 실행하여 리턴 된 객체를 전달합니다.
3. errorMsg에 errors.등록된이름?.message를 전달하면 됩니다.

**테스트 코드**
```
export default function MainWrite() {
  const {
    register,
    handleSubmit,
    formState: { errors },
  } = useForm();

  const onSubmit = formData => {
    console.log(formData);
  };

  return (
    <form className="mb-[40px]" onSubmit={handleSubmit(onSubmit)}>
      <div className="mt-5">
        <InputField
          labelName="제목"
          type="text"
          placeholder="제목"
          register={register("name", { required: "제목 입력은 필수입니다." })}
          errorMsg={errors.name?.message}
        />
      </div>
// ...
```

**테스트 화면**
<img src="https://github.com/user-attachments/assets/1e5db676-fe52-4aa6-b6d4-521e55a40c68" width="400px" />
<img src="https://github.com/user-attachments/assets/b07a3079-5cf1-4f54-b43d-781ccd2a8445" width="400px" />


## 이슈

resolves #81
