### PR TITLE
[FEAT]내가 받은 리뷰 페이지 화면 뿌리는 작업 

### DIFF
--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -1,6 +1,8 @@
 import Button from "@components/layout/Button";
+import { Link, useParams } from "react-router-dom";
 
 export default function MyReviewList({ item }) {
+  const { _id } = useParams();
   if (!item) {
     return <div>데이터가 없습니다.</div>;
   }
@@ -12,24 +14,28 @@ export default function MyReviewList({ item }) {
         <div key={reply._id} className="reviews-container">
           <div className="flex gap-1 ">
             <div className="flex gap-5">
+              {/* <Link to={`/user/:${_id}`}> */}
               <img
                 src="/src/assets/images/smiling_daeddamon.png"
                 alt=""
                 className="size-10"
               />
-              <div className="max-w-[440px]">
-                <p className="font-bold">{reply.user_name}</p>
-                <div className="flex gap-1 size-3 mb-2">
-                  <img src="/icons/reviews/star.svg" />
-                  <img src="/icons/reviews/star.svg" />
-                  <img src="/icons/reviews/star.svg" />
-                  <img src="/icons/reviews/star.svg" />
-                  <img src="/icons/reviews/blankStar.svg" />
+              {/* </Link> */}
+              <Link to={`/main/${_id}`}>
+                <div className="max-w-[440px]">
+                  <p className="font-bold text-sm">{reply.user_name}</p>
+                  <div className="flex gap-1 size-3 mb-2">
+                    <img src="/icons/reviews/star.svg" />
+                    <img src="/icons/reviews/star.svg" />
+                    <img src="/icons/reviews/star.svg" />
+                    <img src="/icons/reviews/star.svg" />
+                    <img src="/icons/reviews/blankStar.svg" />
+                  </div>
+                  <p className="break-keep whitespace-normal text-sm">
+                    {reply.content}
+                  </p>
                 </div>
-                <p className="break-keep whitespace-normal text-sm">
-                  {reply.content}
-                </p>
-              </div>
+              </Link>
             </div>
 
             <Button

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -1,0 +1,49 @@
+import Button from "@components/layout/Button";
+
+export default function MyReviewList({ item }) {
+  if (!item) {
+    return <div>데이터가 없습니다.</div>;
+  }
+  // console.log(item.replies);
+  // const replieList = item.replies.map(re => console.log("re", re));
+  // console.log("rep", replieList);
+  console.log(item);
+  return (
+    <>
+      {item.replies.map(reply => (
+        <div key={reply._id} className="reviews-container">
+          <div className="flex gap-1 ">
+            <div className="flex gap-5">
+              <img
+                src="/src/assets/images/smiling_daeddamon.png"
+                alt=""
+                className="size-10"
+              />
+              <div className="max-w-[440px]">
+                <p className="font-bold">{reply.user_name}</p>
+                <div className="flex gap-1 size-3 mb-2">
+                  <img src="/icons/reviews/star.svg" />
+                  <img src="/icons/reviews/star.svg" />
+                  <img src="/icons/reviews/star.svg" />
+                  <img src="/icons/reviews/star.svg" />
+                  <img src="/icons/reviews/blankStar.svg" />
+                </div>
+                <p className="break-keep whitespace-normal text-sm">
+                  {reply.content}
+                </p>
+              </div>
+            </div>
+
+            <Button
+              height="xs"
+              color="white"
+              className="w-[47px] shrink-0 ml-auto"
+            >
+              신고하기
+            </Button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -27,7 +27,7 @@ export default function MyReviewList({ item }) {
                       ? `https://11.fesp.shop/${reply.image}`
                       : `/src/asset/images/smiling_daeddamon.png`
                   }
-                  alt="사용자 임미지"
+                  alt="사용자 이미지"
                   className="size-10"
                 />
               </Link>

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -5,11 +5,12 @@ import { Link, useParams } from "react-router-dom";
 MyReviewList.propTypes = {
   item: PropTypes.node,
 };
+const alertfun = () => {
+  alert("신고되었습니다");
+};
 export default function MyReviewList({ item }) {
   const { _id } = useParams();
-  function alertfun() {
-    alert("신고되었습니다");
-  }
+
   if (!item) {
     return <div>데이터가 없습니다.</div>;
   }

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -7,7 +7,7 @@ export default function MyReviewList({ item }) {
     return <div>데이터가 없습니다.</div>;
   }
 
-  // console.log(item);
+  console.log(item);
   return (
     <>
       {item.replies.map(reply => (

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -20,8 +20,8 @@ export default function MyReviewList({ item }) {
       {item.replies.map(reply => (
         <div key={reply._id} className="reviews-container">
           <div className="flex gap-1 ">
-            <div className="flex gap-5">
-              <Link to={`/user/${_id}`}>
+            <div className="flex gap-5 flex-grow">
+              <Link to={`/user/${_id}`} className="flex-shrink-0">
                 <img
                   src={
                     reply.image
@@ -32,7 +32,7 @@ export default function MyReviewList({ item }) {
                   className="size-10"
                 />
               </Link>
-              <Link to={`/main/${_id}`}>
+              <Link to={`/main/${_id}`} className="w-full">
                 <div className="max-w-[440px]">
                   <p className="font-bold text-sm">{reply.user_name}</p>
                   <div className="flex gap-1 size-3 mb-2">
@@ -52,7 +52,7 @@ export default function MyReviewList({ item }) {
             <Button
               height="xs"
               color="white"
-              className="w-[47px] shrink-0 ml-auto"
+              className="w-[47px] shrink-0"
               onClick={alertfun}
             >
               신고하기

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -4,10 +4,8 @@ export default function MyReviewList({ item }) {
   if (!item) {
     return <div>데이터가 없습니다.</div>;
   }
-  // console.log(item.replies);
-  // const replieList = item.replies.map(re => console.log("re", re));
-  // console.log("rep", replieList);
-  console.log(item);
+
+  // console.log(item);
   return (
     <>
       {item.replies.map(reply => (

--- a/src/pages/myPage/MyReviewList.jsx
+++ b/src/pages/myPage/MyReviewList.jsx
@@ -1,12 +1,18 @@
 import Button from "@components/layout/Button";
+import PropTypes from "prop-types";
 import { Link, useParams } from "react-router-dom";
 
+MyReviewList.propTypes = {
+  item: PropTypes.node,
+};
 export default function MyReviewList({ item }) {
   const { _id } = useParams();
+  function alertfun() {
+    alert("신고되었습니다");
+  }
   if (!item) {
     return <div>데이터가 없습니다.</div>;
   }
-
   console.log(item);
   return (
     <>
@@ -14,13 +20,17 @@ export default function MyReviewList({ item }) {
         <div key={reply._id} className="reviews-container">
           <div className="flex gap-1 ">
             <div className="flex gap-5">
-              {/* <Link to={`/user/:${_id}`}> */}
-              <img
-                src="/src/assets/images/smiling_daeddamon.png"
-                alt=""
-                className="size-10"
-              />
-              {/* </Link> */}
+              <Link to={`/user/${_id}`}>
+                <img
+                  src={
+                    reply.image
+                      ? `https://11.fesp.shop/${reply.image}`
+                      : `/src/asset/images/smiling_daeddamon.png`
+                  }
+                  alt="사용자 임미지"
+                  className="size-10"
+                />
+              </Link>
               <Link to={`/main/${_id}`}>
                 <div className="max-w-[440px]">
                   <p className="font-bold text-sm">{reply.user_name}</p>
@@ -42,6 +52,7 @@ export default function MyReviewList({ item }) {
               height="xs"
               color="white"
               className="w-[47px] shrink-0 ml-auto"
+              onClick={alertfun}
             >
               신고하기
             </Button>

--- a/src/pages/myPage/MyReviews.jsx
+++ b/src/pages/myPage/MyReviews.jsx
@@ -5,10 +5,13 @@ import { useParams } from "react-router-dom";
 
 export default function MyReviews() {
   const axios = useAxiosInstance();
-  const { _id } = useParams();
+
+  // const { _id } = useParams();
+
   const { data } = useQuery({
     queryKey: ["reviews"],
-    queryFn: () => axios.get(`/replies/seller/${유저아이디임}`),
+    //일단 뿌리기 작업 test를 위해 seller 아이디를 2로 하드코딩, 이후에 로그인 작업이 완료되면 세션스토리지에서 id꺼내 올 예정
+    queryFn: () => axios.get(`/replies/seller/2`),
     select: res => res.data,
     staleTime: 1000 * 10,
   });
@@ -19,7 +22,7 @@ export default function MyReviews() {
   let totalReplies = 0;
   data.item.forEach(item => (totalReplies += item.replies.length));
   // console.log(totalReplies);
-  console.log(data.item);
+  // console.log(data.item);
 
   const list = data.item.map(item => (
     <MyReviewList key={item._id} item={item} />
@@ -28,40 +31,6 @@ export default function MyReviews() {
     <div className="mb-[40px]">
       <p className="font-bold text-[18px] pb-8 px-5">리뷰 {totalReplies}개</p>
       {list}
-      {/* 
-      <div className="reviews-container">
-        <div className="flex gap-1 ">
-          <div className="flex gap-5">
-            <img
-              src="/src/assets/images/smiling_daeddamon.png"
-              alt=""
-              className="size-10"
-            />
-            <div className="max-w-[440px]">
-              <p className="font-bold">리뷰 쓴 사람</p>
-              <div className="flex gap-1 size-3 mb-2">
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/blankStar.svg" />
-              </div>
-              <p className="break-keep whitespace-normal text-sm">
-                이번에 대타로 와주신 김지원 님에 대한 리뷰를 남깁니다. 지원님은
-                연락이 정말 빠르고 정확하게 이루어졌습니다. 처음 대타 요청에
-                응답해 주실 때부터 친절하게 자신의 경력과 가능 여부를 상세히
-                설명해 주셔서 신뢰가 갔습니다. 정리하자면, 지원 님은 성실함,
-                책임감, 그리고 친절함까지 모두 갖춘 알바생이었습니다. 다시 한 번
-                감사드리며, 다음에도 기회가 된다면 꼭 함께 일하고 싶습니다! 😊
-              </p>
-            </div>
-          </div>
-
-          <Button height="xs" color="white" className="w-[47px] shrink-0">
-            신고하기
-          </Button>
-        </div>
-      </div> */}
     </div>
   );
 }

--- a/src/pages/myPage/MyReviews.jsx
+++ b/src/pages/myPage/MyReviews.jsx
@@ -17,11 +17,11 @@ export default function MyReviews() {
     return <div>로딩중</div>;
   }
   // 댓글 수 계산
-  const totalReplies = data.item.reduce(
-    (sum, item) => sum + item.replies.length,
-    0,
-  );
+  let totalReplies = 0;
+  data.item.forEach(item => (totalReplies += item.replies.length));
+  // console.log(totalReplies);
   console.log(data.item);
+
   const list = data.item.map(item => (
     <MyReviewList key={item._id} item={item} />
   ));

--- a/src/pages/myPage/MyReviews.jsx
+++ b/src/pages/myPage/MyReviews.jsx
@@ -8,7 +8,7 @@ export default function MyReviews() {
   const { _id } = useParams();
   const { data } = useQuery({
     queryKey: ["reviews"],
-    queryFn: () => axios.get(`/replies/seller/${_id}`),
+    queryFn: () => axios.get(`/replies/seller/${유저아이디임}`),
     select: res => res.data,
     staleTime: 1000 * 10,
   });

--- a/src/pages/myPage/MyReviews.jsx
+++ b/src/pages/myPage/MyReviews.jsx
@@ -1,11 +1,36 @@
 import Button from "@components/layout/Button";
+import useAxiosInstance from "@hooks/useAxiosInstance";
+import MyReviewList from "@pages/myPage/MyReviewList";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
 
 export default function MyReviews() {
+  const axios = useAxiosInstance();
+  const { _id } = useParams();
+  const { data } = useQuery({
+    queryKey: ["reviews"],
+    queryFn: () => axios.get(`/replies/seller/${_id}`),
+    select: res => res.data,
+    staleTime: 1000 * 10,
+  });
+  if (!data) {
+    return <div>로딩중</div>;
+  }
+  // 댓글 수 계산
+  const totalReplies = data.item.reduce(
+    (sum, item) => sum + item.replies.length,
+    0,
+  );
+  console.log(data.item);
+  const list = data.item.map(item => (
+    <MyReviewList key={item._id} item={item} />
+  ));
   return (
     <div className="mb-[40px]">
-      <p className="font-bold text-[18px] pb-8 px-5">후기 2개</p>
+      <p className="font-bold text-[18px] pb-8 px-5">리뷰 {totalReplies}개</p>
+      {list}
 
-      <div className="reviews-container">
+      {/* <div className="reviews-container">
         <div className="flex gap-1 ">
           <div className="flex gap-5">
             <img
@@ -37,75 +62,7 @@ export default function MyReviews() {
             신고하기
           </Button>
         </div>
-      </div>
-
-      <div className="reviews-container">
-        <div className="flex gap-1 ">
-          <div className="flex gap-5">
-            <img
-              src="/src/assets/images/smiling_daeddamon.png"
-              alt=""
-              className="size-10"
-            />
-            <div className="max-w-[440px]">
-              <p className="font-bold">리뷰 쓴 사람</p>
-              <div className="flex gap-1 size-3 mb-2">
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/blankStar.svg" />
-              </div>
-              <p className="break-keep whitespace-normal text-sm">
-                이번에 대타로 와주신 김지원 님에 대한 리뷰를 남깁니다. 지원님은
-                연락이 정말 빠르고 정확하게 이루어졌습니다. 처음 대타 요청에
-                응답해 주실 때부터 친절하게 자신의 경력과 가능 여부를 상세히
-                설명해 주셔서 신뢰가 갔습니다. 정리하자면, 지원 님은 성실함,
-                책임감, 그리고 친절함까지 모두 갖춘 알바생이었습니다. 다시 한 번
-                감사드리며, 다음에도 기회가 된다면 꼭 함께 일하고 싶습니다! 😊
-              </p>
-            </div>
-          </div>
-
-          <Button height="xs" color="white" className="w-[47px] shrink-0">
-            신고하기
-          </Button>
-        </div>
-      </div>
-
-      <div className="reviews-container">
-        <div className="flex gap-1 ">
-          <div className="flex gap-5">
-            <img
-              src="/src/assets/images/smiling_daeddamon.png"
-              alt=""
-              className="size-10"
-            />
-            <div className="max-w-[440px]">
-              <p className="font-bold">리뷰 쓴 사람</p>
-              <div className="flex gap-1 size-3 mb-2">
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/star.svg" />
-                <img src="/icons/reviews/blankStar.svg" />
-              </div>
-              <p className="break-keep whitespace-normal text-sm">
-                이번에 대타로 와주신 김지원 님에 대한 리뷰를 남깁니다. 지원님은
-                연락이 정말 빠르고 정확하게 이루어졌습니다. 처음 대타 요청에
-                응답해 주실 때부터 친절하게 자신의 경력과 가능 여부를 상세히
-                설명해 주셔서 신뢰가 갔습니다. 정리하자면, 지원 님은 성실함,
-                책임감, 그리고 친절함까지 모두 갖춘 알바생이었습니다. 다시 한 번
-                감사드리며, 다음에도 기회가 된다면 꼭 함께 일하고 싶습니다! 😊
-              </p>
-            </div>
-          </div>
-
-          <Button height="xs" color="white" className="w-[47px] shrink-0">
-            신고하기
-          </Button>
-        </div>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/pages/myPage/MyReviews.jsx
+++ b/src/pages/myPage/MyReviews.jsx
@@ -1,4 +1,3 @@
-import Button from "@components/layout/Button";
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import MyReviewList from "@pages/myPage/MyReviewList";
 import { useQuery } from "@tanstack/react-query";
@@ -29,8 +28,8 @@ export default function MyReviews() {
     <div className="mb-[40px]">
       <p className="font-bold text-[18px] pb-8 px-5">리뷰 {totalReplies}개</p>
       {list}
-
-      {/* <div className="reviews-container">
+      {/* 
+      <div className="reviews-container">
         <div className="flex gap-1 ">
           <div className="flex gap-5">
             <img


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

myReview 페이지 data뿌리기 완료했습니다.
화면 작업을 위해 일단 seller 아이디는 2로 하드코딩 했습니다. 
이후에 로그인 작업이 완료되면 세션스토리지에 저장된 user id를 가져올 예정입니다. 
propTypes도 data구조가 test구조라서 일단 node로 해두었습니다.  이후 추가적인 extra data구조가 명확해지면 그것에 맞게 propTypes도 수정 할 것입니다.
프로필 이미지도 default 이미지로 대따몬 추가했습니다. 
신고하기 누르면 alert 알림 나오는것을 구현하였고 , 프로필 이미지를 누르면 프로필 페이지로 이동하고 , 글을 누르면 상세페이지로 이동하는 Link 작업도 추가하였습니다.

review 별 부분은 extra속성으로 받아오는 데이터 형식이 정해지면 어떻게 할지 생각한 뒤에 추후 작업 하겠습니다.

확인해주시고 comment 달아주세요!

![image](https://github.com/user-attachments/assets/9e3e95e1-0089-4138-90a6-0e024829c988)


###브런치 이동
Feat/75-myReview  

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #75 
