### PR TITLE
[FEAT] Main 페이지 구인 글 리스트 보여주기

### DIFF
--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -47,9 +47,9 @@ const formatDate = dateString => {
 
   let month = date.getMonth() + 1;
   let day = date.getDate();
+  console.log(month, day);
 
   const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
-  console.log(date.getDay());
   let weekday = weekdays[date.getDay()];
 
   return `${month}/${day} ${weekday}`;
@@ -77,8 +77,8 @@ export default function ListItem({ data }) {
         </h3>
         <p className="font-semibold">
           {formatDate(data.extra.condition.date)}ㆍ
-          {data.extra.condition.workTime[0]} ~{data.extra.condition.workTime[1]}{" "}
-          ㆍ
+          {data.extra.condition.workTime[0]} ~{" "}
+          {data.extra.condition.workTime[1]}ㆍ
           {getWorkTime(
             data.extra.condition.workTime[0],
             data.extra.condition.workTime[1],
@@ -89,7 +89,7 @@ export default function ListItem({ data }) {
       <div className="flex-shrink-0 screen-530:hidden">
         <img
           className="size-[136px]"
-          src="/src/assets/images/main-sample.png"
+          src={`https://11.fesp.shop/files/final01/${data.mainImages[0].name}`}
         />
       </div>
     </Link>

--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -1,7 +1,11 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+
+ListItem.propTypes = {
+  data: PropTypes.object.isRequired,
+};
+
 // 시작 시간, 마치는 시간을 string을 받아
-
-import { create } from "zustand";
-
 // 일한 시간 number을 반환하는 함수
 const getWorkTime = (start, end) => {
   const startTime = +start.replace(":", "");
@@ -53,7 +57,10 @@ const formatDate = dateString => {
 
 export default function ListItem({ data }) {
   return (
-    <div className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center">
+    <Link
+      to={`main/${data._id}`}
+      className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center"
+    >
       <div className="flex flex-col gap-1">
         <h3 className="font-bold text-[20px]">{data.name}</h3>
         <p className="font-semibold text-gray-500">
@@ -85,6 +92,6 @@ export default function ListItem({ data }) {
           src="/src/assets/images/main-sample.png"
         />
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -88,7 +88,7 @@ export default function ListItem({ data }) {
       </div>
       <div className="flex-shrink-0 screen-530:hidden">
         <img
-          className="size-[136px]"
+          className="size-[136px] object-cover"
           src={`https://11.fesp.shop/files/final01/${data.mainImages[0].name}`}
         />
       </div>

--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -1,0 +1,90 @@
+// 시작 시간, 마치는 시간을 string을 받아
+
+import { create } from "zustand";
+
+// 일한 시간 number을 반환하는 함수
+const getWorkTime = (start, end) => {
+  const startTime = +start.replace(":", "");
+  const endTime = +end.replace(":", "");
+
+  const timeGap = endTime - startTime;
+  return Math.round(timeGap / 100);
+};
+
+// 생성 시간 string을 받아
+// 현재 시간으로부터 지난 시간에 대해 알맞은 string을 리턴하는 함수
+const getTimePassed = createdAt => {
+  const formattedDate = createdAt.replaceAll(".", "-");
+  const diff = new Date() - new Date(formattedDate);
+
+  const sec = diff / 1000;
+  const min = sec / 60;
+  const hours = min / 60;
+  const days = hours / 24;
+
+  if (min < 0) {
+    return "방금 전";
+  } else if (min < 60) {
+    return `${Math.round(min)}분 전`;
+  } else if (hours < 24) {
+    return `${Math.round(hours)}시간 전`;
+  } else if (days < 2) {
+    return "하루 전";
+  } else {
+    return "며칠 전";
+  }
+};
+
+// date string을 받아
+// 월/일 요일 형태의 string으로 변환해주는 함수
+const formatDate = dateString => {
+  console.log(dateString);
+  let date = new Date(dateString);
+
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
+
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  console.log(date.getDay());
+  let weekday = weekdays[date.getDay()];
+
+  return `${month}/${day} ${weekday}`;
+};
+
+export default function ListItem({ data }) {
+  return (
+    <div className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center">
+      <div className="flex flex-col gap-1">
+        <h3 className="font-bold text-[20px]">{data.name}</h3>
+        <p className="font-semibold text-gray-500">
+          {data.extra.condition.company} ㆍ {getTimePassed(data.createdAt)}
+        </p>
+        <h3 className="text-[20px] font-bold text-purple-900">
+          {`${data.price.toLocaleString()}원ㆍ시급 ${Math.round(
+            data.price /
+              getWorkTime(
+                data.extra.condition.workTime[0],
+                data.extra.condition.workTime[1],
+              ),
+          ).toLocaleString()}원`}
+        </h3>
+        <p className="font-semibold">
+          {formatDate(data.extra.condition.date)}ㆍ
+          {data.extra.condition.workTime[0]} ~{data.extra.condition.workTime[1]}{" "}
+          ㆍ
+          {getWorkTime(
+            data.extra.condition.workTime[0],
+            data.extra.condition.workTime[1],
+          )}
+          시간
+        </p>
+      </div>
+      <div className="flex-shrink-0 screen-530:hidden">
+        <img
+          className="size-[136px]"
+          src="/src/assets/images/main-sample.png"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -1,58 +1,9 @@
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
+import { formatDate, getTimePassed, getWorkTime } from "@/utills/func.js";
 
 ListItem.propTypes = {
   data: PropTypes.object.isRequired,
-};
-
-// 시작 시간, 마치는 시간을 string을 받아
-// 일한 시간 number을 반환하는 함수
-const getWorkTime = (start, end) => {
-  const startTime = +start.replace(":", "");
-  const endTime = +end.replace(":", "");
-
-  const timeGap = endTime - startTime;
-  return Math.round(timeGap / 100);
-};
-
-// 생성 시간 string을 받아
-// 현재 시간으로부터 지난 시간에 대해 알맞은 string을 리턴하는 함수
-const getTimePassed = createdAt => {
-  const formattedDate = createdAt.replaceAll(".", "-");
-  const diff = new Date() - new Date(formattedDate);
-
-  const sec = diff / 1000;
-  const min = sec / 60;
-  const hours = min / 60;
-  const days = hours / 24;
-
-  if (min < 0) {
-    return "방금 전";
-  } else if (min < 60) {
-    return `${Math.round(min)}분 전`;
-  } else if (hours < 24) {
-    return `${Math.round(hours)}시간 전`;
-  } else if (days < 2) {
-    return "하루 전";
-  } else {
-    return "며칠 전";
-  }
-};
-
-// date string을 받아
-// 월/일 요일 형태의 string으로 변환해주는 함수
-const formatDate = dateString => {
-  console.log(dateString);
-  let date = new Date(dateString);
-
-  let month = date.getMonth() + 1;
-  let day = date.getDate();
-  console.log(month, day);
-
-  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
-  let weekday = weekdays[date.getDay()];
-
-  return `${month}/${day} ${weekday}`;
 };
 
 export default function ListItem({ data }) {

--- a/src/pages/main/MainList.jsx
+++ b/src/pages/main/MainList.jsx
@@ -1,6 +1,32 @@
+import useAxiosInstance from "@hooks/useAxiosInstance";
+import ListItem from "@pages/main/ListItem";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 export default function MainList() {
+  const [data, setData] = useState();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const axios = useAxiosInstance();
+
+  const fetchData = async () => {
+    setIsLoading(true);
+
+    try {
+      const res = await axios.get("/products");
+      setData(res.data.item);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  console.log(data);
   return (
     <div className="mb-[80px] flex flex-col">
       <div className="flex justify-between items-center text-[24px] font-semibold pb-[23px]">
@@ -34,66 +60,13 @@ export default function MainList() {
       </div>
 
       <div className="flex flex-col gap-5">
-        <div className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center">
-          <div className="flex flex-col gap-1">
-            <h3 className="font-bold text-[20px]">
-              기장대게 할인마트 홀 서빙 대타 구함!
-            </h3>
-            <p className="font-semibold text-gray-500">
-              기장대게할인마트ㆍ민락동 ㆍ 1시간 전
-            </p>
-            <h3 className="text-[20px] font-bold text-purple-900">
-              90,000원ㆍ시급 15,000원
-            </h3>
-            <p className="font-semibold">12/19 목ㆍ10:00 ~ 16:00ㆍ6시간</p>
-          </div>
-          <div className="flex-shrink-0 screen-530:hidden">
-            <img
-              className="size-[136px]"
-              src="/src/assets/images/main-sample.png"
-            />
-          </div>
-        </div>
-        <div className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center">
-          <div className="flex flex-col gap-1">
-            <h3 className="font-bold text-[20px]">
-              기장대게 할인마트 홀 서빙 대타 구함!
-            </h3>
-            <p className="font-semibold text-gray-500">
-              기장대게할인마트ㆍ민락동 ㆍ 1시간 전
-            </p>
-            <h3 className="text-[20px] font-bold text-purple-900">
-              90,000원ㆍ시급 15,000원
-            </h3>
-            <p className="font-semibold">12/19 목ㆍ10:00 ~ 16:00ㆍ6시간</p>
-          </div>
-          <div className="flex-shrink-0 screen-530:hidden">
-            <img
-              className="size-[136px]"
-              src="/src/assets/images/main-sample.png"
-            />
-          </div>
-        </div>
-        <div className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-[22px] items-center">
-          <div className="flex flex-col gap-1">
-            <h3 className="font-bold text-[20px]">
-              기장대게 할인마트 홀 서빙 대타 구함!
-            </h3>
-            <p className="font-semibold text-gray-500">
-              기장대게할인마트ㆍ민락동 ㆍ 1시간 전
-            </p>
-            <h3 className="text-[20px] font-bold text-purple-900">
-              90,000원ㆍ시급 15,000원
-            </h3>
-            <p className="font-semibold">12/19 목ㆍ10:00 ~ 16:00ㆍ6시간</p>
-          </div>
-          <div className="flex-shrink-0 screen-530:hidden">
-            <img
-              className="size-[136px]"
-              src="/src/assets/images/main-sample.png"
-            />
-          </div>
-        </div>
+        {isLoading && <p>로딩중...</p>}
+        {data && (
+          <>
+            <ListItem data={data[0]} />
+            <ListItem data={data[1]} />
+          </>
+        )}
       </div>
 
       <Link

--- a/src/pages/main/MainList.jsx
+++ b/src/pages/main/MainList.jsx
@@ -26,7 +26,6 @@ export default function MainList() {
     fetchData();
   }, []);
 
-  console.log(data);
   return (
     <div className="mb-[80px] flex flex-col">
       <div className="flex justify-between items-center text-[24px] font-semibold pb-[23px]">

--- a/src/pages/main/MainList.jsx
+++ b/src/pages/main/MainList.jsx
@@ -1,30 +1,17 @@
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import ListItem from "@pages/main/ListItem";
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 
 export default function MainList() {
-  const [data, setData] = useState();
-  const [isLoading, setIsLoading] = useState(false);
-
   const axios = useAxiosInstance();
 
-  const fetchData = async () => {
-    setIsLoading(true);
-
-    try {
-      const res = await axios.get("/products");
-      setData(res.data.item);
-    } catch (error) {
-      console.log(error);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
+  const { data, isLoading } = useQuery({
+    queryKey: ["posts"],
+    queryFn: () => axios.get("/products"),
+    select: res => res.data.item,
+    staleTime: 1000 * 10,
+  });
 
   return (
     <div className="mb-[80px] flex flex-col">

--- a/src/utills/func.js
+++ b/src/utills/func.js
@@ -1,0 +1,51 @@
+// 시작 시간, 마치는 시간 string을 받아
+// 일한 시간 number을 반환하는 함수
+const getWorkTime = (start, end) => {
+  const startTime = +start.replace(":", "");
+  const endTime = +end.replace(":", "");
+
+  const timeGap = endTime - startTime;
+  return Math.round(timeGap / 100);
+};
+
+// 생성 시간 string을 받아
+// 현재 시간으로부터 지난 시간에 대해 알맞은 string을 리턴하는 함수
+const getTimePassed = createdAt => {
+  const formattedDate = createdAt.replaceAll(".", "-");
+  const diff = new Date() - new Date(formattedDate);
+
+  const sec = diff / 1000;
+  const min = sec / 60;
+  const hours = min / 60;
+  const days = hours / 24;
+
+  if (min < 0) {
+    return "방금 전";
+  } else if (min < 60) {
+    return `${Math.round(min)}분 전`;
+  } else if (hours < 24) {
+    return `${Math.round(hours)}시간 전`;
+  } else if (days < 2) {
+    return "하루 전";
+  } else {
+    return "며칠 전";
+  }
+};
+
+// date string을 받아
+// 월/일 요일 형태의 string으로 변환해주는 함수
+const formatDate = dateString => {
+  console.log(dateString);
+  let date = new Date(dateString);
+
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
+  console.log(month, day);
+
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
+  let weekday = weekdays[date.getDay()];
+
+  return `${month}/${day} ${weekday}`;
+};
+
+export { getWorkTime, getTimePassed, formatDate };


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

**설명**

products 목록을 useQuery로 받아서 data를 화면에 알맞게 뿌려줍니다.

![image](https://github.com/user-attachments/assets/3ce5e1a3-35f1-46db-bc6d-fe56ce440a76)

구인 글은 컴포넌트로 분리했고, 현재는 특정 데이터를 props로 전달하게 하드코딩했습니다.

데이터 초기화 작업이 끝나면 map으로 뿌릴 생각입니다.

**함수**

ListItem.jsx에 자주 사용되는 함수들을 src/utils/func.js에 모았습니다.

함수 목록

- getWorkTime
: 시작 시간, 마치는 시간 string을 받아 일한 시간 number을 반환하는 함수
```
입력: "11:00", "19:00"
출력: 8
```

- getTimePassed
: 생성 시간 string을 받아 현재 시간으로부터 지난 시간에 대해 알맞은 string을 리턴하는 함수
```
입력: "2025.01.02 21:19:36" (createdAt)
출력: "며칠 전" (1일 초과)
```

- formatDate
: date string을 받아 월/일 요일 형태의 string으로 변환해주는 함수
```
입력: "2025-01-14"
출력: "1/14 (토)"
```

## 이슈

resolves #83
