### PR TITLE
[FEAT] 메인 상세 페이지 input 데이터 출력

### DIFF
--- a/api/bruno-sample/dda/05.게시판(QnA, 공지 등)/01.목록 조회/게시물 목록 조회(검색, 상품 id).bru
+++ b/api/bruno-sample/dda/05.게시판(QnA, 공지 등)/01.목록 조회/게시물 목록 조회(검색, 상품 id).bru
@@ -5,14 +5,14 @@ meta {
 }
 
 get {
-  url: {{url}}/posts?type=qna&custom={"product_id":1}
+  url: {{url}}/posts?type=pr&custom={"product_id":18}
   body: none
   auth: none
 }
 
 params:query {
-  type: qna
-  custom: {"product_id":1}
+  type: pr
+  custom: {"product_id":18}
   ~type: notice
   ~type: 원하는값
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
         "axios": "^1.7.9",
+        "dompurify": "^3.2.3",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1506,6 +1507,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
@@ -2318,6 +2326,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",
     "axios": "^1.7.9",
+    "dompurify": "^3.2.3",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/routes.jsx
+++ b/routes.jsx
@@ -44,7 +44,7 @@ const router = createBrowserRouter(
             { path: "myPerson", element: <MyPerson /> },
           ],
         },
-        { path: "review/write", element: <ReviewWrite /> },
+        { path: "review/:_id/write", element: <ReviewWrite /> },
 
         { path: "pr/write", element: <PRWrite /> },
         { path: "pr/:_id", element: <PRDetail /> },

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -55,7 +55,7 @@ export default function Header() {
 
   if (headerMatch) {
     return (
-      <header className="w-full h-[60px] flex items-center justify-center border-b border-gray-200 mb-5 fixed top-0 max-w-screen-sm left-1/2 -translate-x-1/2 bg-white px-6">
+      <header className="w-full h-[60px] flex items-center justify-center border-b border-gray-200 mb-5 fixed top-0 max-w-screen-sm left-1/2 -translate-x-1/2 bg-white px-6 z-10">
         <img
           src="/icons/back.svg"
           className="absolute left-[16px] w-6 h-6 hover:cursor-pointer"
@@ -69,7 +69,7 @@ export default function Header() {
   }
 
   return (
-    <header className="w-full h-[60px] flex items-center justify-between fixed top-0 max-w-screen-sm left-1/2 -translate-x-1/2 bg-white px-6">
+    <header className="w-full h-[60px] flex items-center justify-between fixed top-0 max-w-screen-sm left-1/2 -translate-x-1/2 bg-white px-6 z-10">
       <Link to="/">
         <img
           src="/src/assets/logos/header-logo.png"

--- a/src/pages/main/MainDetail.jsx
+++ b/src/pages/main/MainDetail.jsx
@@ -1,11 +1,11 @@
 import Button from "@components/layout/Button";
 import useAxiosInstance from "@hooks/useAxiosInstance";
-import Badge from "@pages/main/Badge";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import useUserStore from "@zustand/userStore";
 import { useNavigate, useParams } from "react-router-dom";
 import { getWorkTime, formatDate } from "@/utills/func";
 import DOMPurify from "dompurify";
+import MainItem from "@pages/main/MainItem";
 
 export default function MainDetail() {
   const queryClient = useQueryClient();
@@ -140,15 +140,21 @@ export default function MainDetail() {
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
               <h2 className="">{data?.item.extra.condition.date}</h2>
             </article>
-            <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
+            <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center flex-wrap">
               <h2 className="">
                 {data?.item?.extra?.condition?.workTime
-                  ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition.workTime[1]}ㆍ${getWorkTime(
-                      data.item.extra.condition.workTime[0],
-                      data.item.extra.condition.workTime[1],
-                    )}` + "시간"
+                  ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition.workTime[1]}`
                   : "근무 시간이 제공되지 않았습니다."}
               </h2>
+              <span className="screen-400:hidden">ㆍ</span>
+              {data?.item?.extra?.condition?.workTime && (
+                <h2 className="">
+                  {`${getWorkTime(
+                    data.item.extra.condition.workTime[0],
+                    data.item.extra.condition.workTime[1],
+                  )}시간`}
+                </h2>
+              )}
             </article>
           </div>
         </section>
@@ -174,61 +180,7 @@ export default function MainDetail() {
             지원하기
           </Button>
         </div>
-
-        <div>
-          <section className="mt-7 pt-7 flex justify-between border-t-8">
-            <div className="flex items-center gap-3">
-              <img
-                src="/src/assets/images/smiling_daeddamon.png"
-                className="w-16 h-16"
-                alt="스마일 대따몬"
-              />
-              <div className="flex flex-col">
-                <div className="flex">
-                  <h2 className="font-bold mr-1">닉네임</h2>
-                  <Badge number={70} />
-                </div>
-                <h2 className="font-light">2024/12/25</h2>
-              </div>
-            </div>
-            <div className="flex w-[78px] ml-auto">
-              <Button color="white" height="sm">
-                상세 내역
-              </Button>
-            </div>
-          </section>
-
-          <section className="break-keep whitespace-normal">
-            <div className="font-bold mt-7">근무 조건</div>
-            <div className="mt-2">
-              카카오 프론트엔드 개발자 지원합니다! 열심히 하겠습니다.
-            </div>
-
-            <div className="font-bold mt-7">휴대폰 번호</div>
-            <div className="mt-2">010-xxxx-xxxx</div>
-
-            <div className="font-bold mt-7">상세 경력</div>
-            <div className="mt-2">
-              카카오 프론트엔드 개발자 지원합니다! 열심히 하겠습니다.
-            </div>
-
-            <div className="font-bold mt-7 ">자신을 표현해주세요!</div>
-            <div className="mt-2">프로젝트에서 말하는 감자를 담당했습니다.</div>
-
-            <div className="flex gap-2 h-[32px] justify-center my-10">
-              <div className="w-72">
-                <Button color="purple" width="xl" height="sm">
-                  채택
-                </Button>
-              </div>
-              <div className="w-72">
-                <Button color="red" width="2xl" height="sm">
-                  취소
-                </Button>
-              </div>
-            </div>
-          </section>
-        </div>
+        <MainItem />
       </div>
     </div>
   );

--- a/src/pages/main/MainDetail.jsx
+++ b/src/pages/main/MainDetail.jsx
@@ -135,13 +135,13 @@ export default function MainDetail() {
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
               <h2 className="">{data?.item.extra.condition?.date}</h2>
             </article>
-            <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center flex-wrap">
+            <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center screen-425:flex-col">
               <h2 className="">
                 {data?.item?.extra?.condition?.workTime
                   ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition?.workTime[1]}`
                   : "근무 시간이 제공되지 않았습니다."}
               </h2>
-              <span className="screen-400:hidden">ㆍ</span>
+              <span className="screen-425:hidden">ㆍ</span>
               {data?.item?.extra?.condition?.workTime && (
                 <h2 className="">
                   {`${getWorkTime(

--- a/src/pages/main/MainDetail.jsx
+++ b/src/pages/main/MainDetail.jsx
@@ -22,8 +22,6 @@ export default function MainDetail() {
 
   const sanitizedContent = DOMPurify.sanitize(`${data?.item.content}`);
 
-  console.log(data?.item);
-
   const removePost = useMutation({
     mutationFn: _id => axios.delete(`/seller/products/${_id}`),
 
@@ -60,10 +58,7 @@ export default function MainDetail() {
   });
 
   const handleEdit = () => {
-    const editPost = window.confirm("수정 하시겠습니까?");
-    if (editPost) {
-      editDetailPost.mutate(_id);
-    }
+    editDetailPost.mutate(_id);
   };
 
   const handleApply = () => {

--- a/src/pages/main/MainDetail.jsx
+++ b/src/pages/main/MainDetail.jsx
@@ -122,7 +122,7 @@ export default function MainDetail() {
         <h2 className="font-bold mb-2">위치</h2>
         <div className="w-full h-40 bg-slate-600 rounded-lg"></div>
         <div className="mt-4 sm:whitespace-normal md:whitespace-nowrap">
-          {data?.item.extra.addres}
+          {data?.item.extra.address}
         </div>
       </section>
 
@@ -132,26 +132,26 @@ export default function MainDetail() {
 
           <div className="grid custom-375:grid-cols-1 grid-cols-2  gap-6">
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">{data?.item.extra.condition.company}</h2>
+              <h2 className="">{data?.item.extra.condition?.company}</h2>
             </article>
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
               <h2 className="">{data?.item.price} 원</h2>
             </article>
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">{data?.item.extra.condition.date}</h2>
+              <h2 className="">{data?.item.extra.condition?.date}</h2>
             </article>
             <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center flex-wrap">
               <h2 className="">
                 {data?.item?.extra?.condition?.workTime
-                  ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition.workTime[1]}`
+                  ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition?.workTime[1]}`
                   : "근무 시간이 제공되지 않았습니다."}
               </h2>
               <span className="screen-400:hidden">ㆍ</span>
               {data?.item?.extra?.condition?.workTime && (
                 <h2 className="">
                   {`${getWorkTime(
-                    data.item.extra.condition.workTime[0],
-                    data.item.extra.condition.workTime[1],
+                    data.item.extra.condition?.workTime[0],
+                    data.item.extra.condition?.workTime[1],
                   )}시간`}
                 </h2>
               )}

--- a/src/pages/main/MainDetail.jsx
+++ b/src/pages/main/MainDetail.jsx
@@ -1,36 +1,120 @@
 import Button from "@components/layout/Button";
+import useAxiosInstance from "@hooks/useAxiosInstance";
 import Badge from "@pages/main/Badge";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import useUserStore from "@zustand/userStore";
+import { useNavigate, useParams } from "react-router-dom";
+import { getWorkTime, formatDate } from "@/utills/func";
+import DOMPurify from "dompurify";
 
 export default function MainDetail() {
+  const queryClient = useQueryClient();
+  const { user } = useUserStore();
+  const axios = useAxiosInstance();
+  const navigate = useNavigate();
+  const { _id } = useParams();
+
+  const { data } = useQuery({
+    queryKey: ["seller/products", _id],
+    queryFn: () => axios.get(`/seller/products/${_id}`),
+    select: res => res.data,
+  });
+
+  const sanitizedContent = DOMPurify.sanitize(`${data?.item.content}`);
+
+  console.log(data?.item);
+
+  const removePost = useMutation({
+    mutationFn: _id => axios.delete(`/seller/products/${_id}`),
+
+    onSuccess: () => {
+      alert("공고 페이지가 삭제되었습니다.");
+      queryClient.invalidateQueries(["seller/products"]);
+      navigate("/");
+    },
+
+    onError: error => {
+      console.error("삭제 실패", error);
+      alert("삭제에 실패했습니다.");
+    },
+  });
+
+  const handleDelete = () => {
+    const deletePost = window.confirm("삭제 하시겠습니까?");
+    if (deletePost) {
+      removePost.mutate(_id);
+    }
+  };
+
+  const editDetailPost = useMutation({
+    mutationFn: _id => axios.patch(`/seller/products/${_id}`),
+
+    onSuccess: () => {
+      navigate(`/main/${_id}/edit`);
+    },
+
+    onError: error => {
+      console.error("글 수정", error);
+      alert("글 수정에 실패했습니다.");
+    },
+  });
+
+  const handleEdit = () => {
+    const editPost = window.confirm("수정 하시겠습니까?");
+    if (editPost) {
+      editDetailPost.mutate(_id);
+    }
+  };
+
+  const handleApply = () => {
+    const applyPost = window.confirm("지원 하시겠습니까?");
+    if (applyPost) {
+      navigate("/pr/write");
+    }
+  };
+
   return (
     <div className="mb-[40px]">
-      <section className="flex items-center justify-between h-[60px] mt-4">
+      <section className="flex items-center justify-between mt-4 flex-wrap">
         <div className="font-bold text-[20px] py-4 break-keep whitespace-normal">
-          카카오 프론트엔드 개발자 구합니다
+          {data?.item.name}
         </div>
-        <img
+        {/* <img
           src="/icons/blackHeart.svg"
           className="h-7 w-7 ml-2"
           alt="찜 아이콘"
-        />
+        /> */}
+        <div className="flex justify-end gap-2 screen-530:justify-end screen-530:w-full">
+          <div className="w-[92px] h-[32px]">
+            <Button color="purple" width="xl" height="sm" onClick={handleEdit}>
+              수정
+            </Button>
+          </div>
+
+          <div className="w-[92px] h-[32px]">
+            <Button color="red" width="2xl" height="sm" onClick={handleDelete}>
+              삭제
+            </Button>
+          </div>
+        </div>
       </section>
 
       <section className="flex items-center h-20 shadow-custom-shadow rounded-3xl mt-6 p-3">
         <img
-          src="/src/assets/images/daeddamon.png"
-          className="w-11 h-11 ml-3"
-          alt="스마일 대따몬"
+          src={`https://11.fesp.shop/${data?.item.seller.image}`}
+          className="w-11 h-11"
+          alt="프로필 이미지"
         />
-        <h2 className="font-bold ml-5">닉네임</h2>
-        <h2 className="font-light ml-5">2024/12/25</h2>
+        <h2 className="font-bold ml-5">{data?.item.seller.name}</h2>
+        <h2 className="font-light ml-5">{formatDate(data?.item.createdAt)}</h2>
       </section>
 
       <section className="mt-7">
         <h2 className="font-bold mb-2">근무지 사진</h2>
         <div className="mt-2 mb-7 w-[136px] h-[136px] flex bg-slate-600 items-center justify-center rounded-lg cursor-pointer">
           <img
-            src=""
-            alt="업로드된 이미지"
+            src={`https://11.fesp.shop/files/final01/${data?.item.mainImages[0].name}`}
+            alt="근무지 이미지"
             className="w-full h-full object-cover rounded-lg"
           />
         </div>
@@ -38,7 +122,7 @@ export default function MainDetail() {
         <h2 className="font-bold mb-2">위치</h2>
         <div className="w-full h-40 bg-slate-600 rounded-lg"></div>
         <div className="mt-4 sm:whitespace-normal md:whitespace-nowrap">
-          제주특별자치도 제주시 첨단로 242 (우)63309
+          {data?.item.extra.addres}
         </div>
       </section>
 
@@ -48,16 +132,23 @@ export default function MainDetail() {
 
           <div className="grid custom-375:grid-cols-1 grid-cols-2  gap-6">
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">카카오</h2>
+              <h2 className="">{data?.item.extra.condition.company}</h2>
             </article>
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">일급: 100,000원 + 중식비</h2>
+              <h2 className="">{data?.item.price} 원</h2>
             </article>
             <article className="flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">2024/12/25 목요일</h2>
+              <h2 className="">{data?.item.extra.condition.date}</h2>
             </article>
             <article className=" flex items-center justify-center h-20 shadow-custom-shadow rounded-lg p-3 text-center">
-              <h2 className="">09:00~18:00</h2>
+              <h2 className="">
+                {data?.item?.extra?.condition?.workTime
+                  ? `${data.item.extra.condition.workTime[0]} ~ ${data.item.extra.condition.workTime[1]}ㆍ${getWorkTime(
+                      data.item.extra.condition.workTime[0],
+                      data.item.extra.condition.workTime[1],
+                    )}` + "시간"
+                  : "근무 시간이 제공되지 않았습니다."}
+              </h2>
             </article>
           </div>
         </section>
@@ -65,13 +156,21 @@ export default function MainDetail() {
           <div>
             <h2 className="font-bold ml-3">근무 내용</h2>
             <ul className="ml-8 mt-2 break-keep whitespace-normal">
-              카카오 프렌즈 홈페이지 UI 작업 카카오뱅크 신사업 분야의 프론트엔드
-              개발과 운영 서비스 운영도구 개발 및 관리 효율화 업무 채용시 연락
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: sanitizedContent,
+                }}
+              ></span>
             </ul>
           </div>
         </section>
         <div className="mt-7 ">
-          <Button color="purple" height="lg" type="submit">
+          <Button
+            color="purple"
+            height="lg"
+            type="submit"
+            onClick={handleApply}
+          >
             지원하기
           </Button>
         </div>

--- a/src/pages/main/MainItem.jsx
+++ b/src/pages/main/MainItem.jsx
@@ -42,7 +42,7 @@ export default function MainItem() {
                   </div>
                 </div>
                 <div className="flex w-[78px] ml-auto">
-                  <Button color="white" height="sm">
+                  <Button color="white" height="sm" onClick={handleDetail}>
                     상세 내역
                   </Button>
                 </div>

--- a/src/pages/main/MainItem.jsx
+++ b/src/pages/main/MainItem.jsx
@@ -1,0 +1,84 @@
+import Button from "@components/layout/Button";
+import useAxiosInstance from "@hooks/useAxiosInstance";
+import Badge from "@pages/main/Badge";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router-dom";
+
+export default function MainItem() {
+  const axios = useAxiosInstance();
+  const navigate = useNavigate();
+
+  const { _id } = useParams();
+  const { data: comments } = useQuery({
+    queryKey: ["comments", _id],
+    queryFn: () => axios.get(`/posts?type=pr&custom={"product_id":${_id}}`),
+    select: res => res.data.item,
+  });
+
+  console.log(comments);
+
+  const handleDetail = () => {
+    navigate(`pr/${_id}/edit`);
+  };
+
+  return (
+    <div>
+      {comments && comments.length > 0
+        ? comments.map(comment => (
+            <div key={comment?._id}>
+              <section className="mt-7 pt-7 flex justify-between border-t-8">
+                <div className="flex items-center gap-3">
+                  <img
+                    src={`https://11.fesp.shop/files/final01/${comment?.user.image}`}
+                    className="w-16 h-16"
+                    alt={`${comment?.user.name} 프로필 이미지`}
+                  />
+                  <div className="flex flex-col">
+                    <div className="flex">
+                      <h2 className="font-bold mr-1">{comment?.user.name}</h2>
+                      <Badge number={70} />
+                    </div>
+                    <h2 className="font-light">{comment?.updatedAt}</h2>
+                  </div>
+                </div>
+                <div className="flex w-[78px] ml-auto">
+                  <Button color="white" height="sm">
+                    상세 내역
+                  </Button>
+                </div>
+              </section>
+
+              <section className="break-keep whitespace-normal">
+                <div className="font-bold mt-7">제목</div>
+                <div className="mt-2">{comment?.title}</div>
+
+                <div className="font-bold mt-7">휴대폰 번호</div>
+                <div className="mt-2">{comment?.extra.phone}</div>
+
+                <div className="font-bold mt-7" onClick={handleDetail}>
+                  상세 경력
+                </div>
+                <div className="mt-2">{comment?.extra.detail}</div>
+
+                <div className="font-bold mt-7 ">자신을 표현해주세요!</div>
+                <div className="mt-2">{comment?.content}</div>
+
+                <div className="flex gap-2 h-[32px] justify-center my-10">
+                  <div className="w-72">
+                    <Button color="purple" width="xl" height="sm">
+                      채택
+                    </Button>
+                  </div>
+                  <div className="w-72">
+                    <Button color="red" width="2xl" height="sm">
+                      거절
+                    </Button>
+                  </div>
+                </div>
+              </section>
+            </div>
+          ))
+        : ""}
+    </div>
+  );
+}

--- a/src/pages/main/MainItem.jsx
+++ b/src/pages/main/MainItem.jsx
@@ -64,16 +64,16 @@ export default function MainItem() {
                 <div className="mt-2">{comment?.content}</div>
 
                 <div className="flex gap-2 h-[32px] justify-center my-10">
-                  <div className="w-72">
-                    <Button color="purple" width="xl" height="sm">
+                  <div className="w-full">
+                    <Button color="purple" width="xl" height="lg">
                       채택
                     </Button>
                   </div>
-                  <div className="w-72">
-                    <Button color="red" width="2xl" height="sm">
+                  {/* <div className="w-full">
+                    <Button color="red" width="xl" height="lg">
                       거절
                     </Button>
-                  </div>
+                  </div> */}
                 </div>
               </section>
             </div>

--- a/src/pages/main/MainWrite.jsx
+++ b/src/pages/main/MainWrite.jsx
@@ -6,6 +6,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import DOMPurify from "dompurify";
 
 export default function MainWrite() {
   const navigate = useNavigate();
@@ -25,7 +26,7 @@ export default function MainWrite() {
         name: formData.name,
         price: formData.price,
         quantity: 1,
-        content: formData.content,
+        content: DOMPurify.sanitize(formData.content, { ALLOWED_TAGS: [] }),
         extra: {
           location: [35.155625, 129.131793],
           address: formData.address,

--- a/src/pages/main/MainWrite.jsx
+++ b/src/pages/main/MainWrite.jsx
@@ -87,7 +87,13 @@ export default function MainWrite() {
           labelName="제목"
           type="text"
           placeholder="제목"
-          register={register("name", { required: "제목 입력은 필수입니다." })}
+          register={register("name", {
+            required: "제목 입력은 필수입니다.",
+            minLength: {
+              value: 2,
+              message: "제목은 최소 2자 이상 입력해주세요.",
+            },
+          })}
           errorMsg={errors.name?.message}
         />
       </div>
@@ -178,6 +184,9 @@ export default function MainWrite() {
               message: "숫자만 입력해주세요.",
             },
           })}
+          onInput={e => {
+            e.target.value = e.target.value.replace(/\s+/g, "");
+          }}
           errorMsg={errors.price?.message}
         />
 
@@ -198,6 +207,9 @@ export default function MainWrite() {
           register={register("date", {
             required: "날짜 입력은 필수입니다.",
           })}
+          onInput={e => {
+            e.target.value = e.target.value.replace(/\s+/g, "");
+          }}
           errorMsg={errors.date?.message}
         />
       </fieldset>

--- a/src/pages/main/MainWrite.jsx
+++ b/src/pages/main/MainWrite.jsx
@@ -80,6 +80,12 @@ export default function MainWrite() {
     }
   };
 
+  const handleConfirm = () => {
+    window.confirm(
+      "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Est atque commodi tempore quis eos nesciunt molestiae dicta cum harum quia ipsam, pariatur earum. In, soluta voluptatem ab ut deserunt doloribus.Lorem ipsum, dolor sit amet consectetur adipisicing elit. Est atque commodi tempore quis eos nesciunt molestiae dicta cum harum quia ipsam, pariatur earum. In, soluta voluptatem ab ut deserunt doloribus.",
+    );
+  };
+
   return (
     <form className="mb-[40px]" onSubmit={handleSubmit(addPost.mutate)}>
       <div className="mt-5">
@@ -232,7 +238,12 @@ export default function MainWrite() {
         />
       </fieldset>
       <div className="mt-11">
-        <Button color="purple" height="lg" type="submit">
+        <Button
+          color="purple"
+          height="lg"
+          type="submit"
+          onClick={handleConfirm}
+        >
           등록
         </Button>
       </div>

--- a/src/pages/main/MainWrite.jsx
+++ b/src/pages/main/MainWrite.jsx
@@ -176,7 +176,7 @@ export default function MainWrite() {
 
         <InputField
           type="text"
-          placeholder="급여"
+          placeholder="급여는 숫자만 입력주세요."
           register={register("price", {
             required: "급여 입력은 필수입니다.",
             pattern: {
@@ -218,6 +218,7 @@ export default function MainWrite() {
         <InputField
           type="text"
           labelName="근무 내용"
+          placeholder="상세한 근무 내용을 적어주세요."
           id="workTxt"
           isTextArea={true}
           register={register("content", {


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

메인 글쓰기 펭페이지에서 사용자가 입력한 input 데이터 보여주기
![image](https://github.com/user-attachments/assets/bf7554e1-ea75-4b94-9e4d-f304f9e111b7)

수정 및 삭제 버튼 클릭 시 삭제 메세지 출력
![image](https://github.com/user-attachments/assets/f7617b0d-4efa-4300-ad72-cc73205e3e4b)

PR 부분, 컴포넌트화 및 상세내역 클릭 시 상세로 이동
![image](https://github.com/user-attachments/assets/b1e7fbba-eeba-46c8-b488-5d5357b2ce06)

글쓰기 페이지에서 textarea로 된 input에 데이터를 입력하게 되면 서버에서 받을 때, 태그가 포함된 상태로 전송이 된다.
DOMPurify 추가하여 XSS 예방

### 테스트
git checkout feat/80-mainDetailPage 로 이동
MainDetail, MainItem에서 확인

## 이슈

resolves #80  #99 #103
