### PR TITLE
[FEAT] 로그인이 필요한 페이지 ProtectedRoutes 로 막기

### DIFF
--- a/ProtectedRoutes.jsx
+++ b/ProtectedRoutes.jsx
@@ -4,7 +4,11 @@ import useUserStore from "@zustand/userStore";
 const ProtectedRoute = () => {
   const user = useUserStore(state => state.user);
 
-  return user ? <Outlet /> : <Navigate to="/user/signIn" replace />;
+  if (!user) {
+    alert("로그인 필요 - protected route");
+    return <Navigate to="/user/signIn" replace />;
+  }
+  return <Outlet />;
 };
 
 export default ProtectedRoute;

--- a/ProtectedRoutes.jsx
+++ b/ProtectedRoutes.jsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from "react-router-dom";
+import useUserStore from "@zustand/userStore";
+
+const ProtectedRoute = () => {
+  const user = useUserStore(state => state.user);
+
+  return user ? <Outlet /> : <Navigate to="/user/signIn" replace />;
+};
+
+export default ProtectedRoute;

--- a/ProtectedRoutes.jsx
+++ b/ProtectedRoutes.jsx
@@ -6,7 +6,7 @@ const ProtectedRoute = () => {
 
   if (!user) {
     alert("로그인 필요 - protected route");
-    return <Navigate to="/user/signIn" replace />;
+    return <Navigate to="/user/signIn" replace={true} />;
   }
   return <Outlet />;
 };

--- a/routes.jsx
+++ b/routes.jsx
@@ -20,6 +20,9 @@ import Employed from "@pages/history/Employed";
 import ReviewWrite from "@pages/history/ReviewWrite";
 import KakaoSignIn from "@pages/user/KakaoSignIn";
 import Alarm from "@pages/alarm/Alarm";
+import ProtectedRoute from "./protectedRoutes";
+
+// 접근 막을 페이지: nav 기준 마이페이지, 알바 내역 페이지
 
 const router = createBrowserRouter(
   [
@@ -29,36 +32,66 @@ const router = createBrowserRouter(
       children: [
         { index: true, element: <PostList /> },
 
-        { path: "alarm", element: <Alarm /> },
-        { path: "post/write", element: <PostWrite /> },
+        {
+          element: <ProtectedRoute />,
+          children: [
+            { path: "alarm", element: <Alarm /> },
+            { path: "post/write", element: <PostWrite /> },
+            { path: "post/:_id/edit", element: <PostEdit /> },
+            { path: "pr/write", element: <PRWrite /> },
+          ],
+        },
+
         { path: "post/:_id", element: <PostDetail /> },
-        { path: "post/:_id/edit", element: <PostEdit /> },
 
         {
           path: "history",
           element: <ReviewList />,
           children: [
             {
+              element: <ProtectedRoute />,
+              children: [
+                { path: "worked", element: <Worked /> },
+                { path: "employed", element: <Employed /> },
+                {
+                  path: ":from/reviewWrite/:id",
+                  element: <ReviewWrite />,
+                },
+              ],
+            },
+            {
               index: true,
               element: <Navigate to="worked" replace />,
             },
-            { path: "worked", element: <Worked /> },
-            { path: "employed", element: <Employed /> },
           ],
         },
-        { path: "history/:from/reviewWrite/:id", element: <ReviewWrite /> },
+        // { path: "history/:from/reviewWrite/:id", element: <ReviewWrite /> },
+        // { path: "pr/write", element: <PRWrite /> },
 
-        { path: "pr/write", element: <PRWrite /> },
+        {
+          path: "myPage",
+          children: [
+            {
+              element: <ProtectedRoute />,
+              children: [
+                { index: true, element: <MyPage /> },
+                { path: "myPage/edit", element: <Edit /> },
+                { path: "myPage/likeList", element: <Likes /> },
+                { path: "myPage/myReviews/:_id", element: <MyReviews /> },
+              ],
+            },
+          ],
+        },
 
-        { path: "myPage", element: <MyPage /> },
-        { path: "myPage/edit", element: <Edit /> },
-        { path: "myPage/likeList", element: <Likes /> },
-        { path: "myPage/myReviews/:_id", element: <MyReviews /> },
+        {
+          path: "user/:_id",
+          element: <ProtectedRoute />,
+          children: [{ index: true, element: <Profile /> }],
+        },
 
+        { path: "error", element: <Error /> },
         { path: "user/signUp", element: <SignUp /> },
         { path: "user/terms", element: <Terms /> },
-        { path: "user/:_id", element: <Profile /> },
-        { path: "error", element: <Error /> },
       ],
     },
 

--- a/routes.jsx
+++ b/routes.jsx
@@ -27,82 +27,59 @@ import ProtectedRoute from "./protectedRoutes";
 const router = createBrowserRouter(
   [
     {
-      path: "/",
       element: <Layout />,
       children: [
-        { index: true, element: <PostList /> },
-
+        // 로그인이 필요 없는 페이지
+        { path: "/", element: <PostList /> },
+        { path: "post/:_id", element: <PostDetail /> },
+        { path: "error", element: <Error /> },
         {
+          path: "user",
+          children: [
+            { path: "user/signUp", element: <SignUp /> },
+            { path: "user/terms", element: <Terms /> },
+            { path: "user/signIn", element: <SignIn /> },
+          ],
+        },
+        {
+          // 로그인이 필요한 페이지
           element: <ProtectedRoute />,
           children: [
             { path: "alarm", element: <Alarm /> },
             { path: "post/write", element: <PostWrite /> },
             { path: "post/:_id/edit", element: <PostEdit /> },
             { path: "pr/write", element: <PRWrite /> },
-          ],
-        },
-
-        { path: "post/:_id", element: <PostDetail /> },
-
-        {
-          path: "history",
-          element: <ProtectedRoute />,
-          // element: <ReviewList />,
-          children: [
             {
+              path: "history",
               element: <ReviewList />,
               children: [
                 { path: "worked", element: <Worked /> },
                 { path: "employed", element: <Employed /> },
-                {
-                  path: ":from/reviewWrite/:id",
-                  element: <ReviewWrite />,
-                },
+                { path: ":from/reviewWrite/:id", element: <ReviewWrite /> },
               ],
             },
             {
-              index: true,
-              element: <Navigate to="worked" replace />,
-            },
-          ],
-        },
-        // { path: "history/:from/reviewWrite/:id", element: <ReviewWrite /> },
-        // { path: "pr/write", element: <PRWrite /> },
-
-        {
-          path: "myPage",
-          children: [
-            {
-              element: <ProtectedRoute />,
+              path: "myPage",
               children: [
                 { index: true, element: <MyPage /> },
-                { path: "myPage/edit", element: <Edit /> },
-                { path: "myPage/likeList", element: <Likes /> },
-                { path: "myPage/myReviews/:_id", element: <MyReviews /> },
+                { path: "edit", element: <Edit /> },
+                { path: "likeList", element: <Likes /> },
+                { path: "myReviews/:_id", element: <MyReviews /> },
               ],
             },
+            { path: "user/:_id", element: <Profile /> },
           ],
         },
-
-        {
-          path: "user/:_id",
-          element: <ProtectedRoute />,
-          children: [{ index: true, element: <Profile /> }],
-        },
-
-        { path: "error", element: <Error /> },
-        { path: "user/signUp", element: <SignUp /> },
-        { path: "user/terms", element: <Terms /> },
       ],
     },
 
+    // 레이아웃 필요 없는 페이지
     {
-      path: "user/signIn",
-      element: <SignIn />,
-    },
-    {
-      path: "user/signin/kakao",
-      element: <KakaoSignIn />,
+      path: "user",
+      children: [
+        { path: "signIn", element: <SignIn /> },
+        { path: "signin/kakao", element: <KakaoSignIn /> },
+      ],
     },
   ],
   {

--- a/routes.jsx
+++ b/routes.jsx
@@ -46,10 +46,11 @@ const router = createBrowserRouter(
 
         {
           path: "history",
-          element: <ReviewList />,
+          element: <ProtectedRoute />,
+          // element: <ReviewList />,
           children: [
             {
-              element: <ProtectedRoute />,
+              element: <ReviewList />,
               children: [
                 { path: "worked", element: <Worked /> },
                 { path: "employed", element: <Employed /> },

--- a/routes.jsx
+++ b/routes.jsx
@@ -71,7 +71,6 @@ const router = createBrowserRouter(
             { path: "user/:_id", element: <Profile /> },
           ],
         },
-        { path: "refund", element: <Refund /> },
       ],
     },
 
@@ -83,6 +82,7 @@ const router = createBrowserRouter(
         { path: "signin/kakao", element: <KakaoSignIn /> },
       ],
     },
+    { path: "refund", element: <Refund /> },
   ],
   {
     future: {

--- a/src/hooks/useAxiosInstance.js
+++ b/src/hooks/useAxiosInstance.js
@@ -71,11 +71,12 @@ function useAxiosInstance() {
 
           config.headers.Authorization = `Bearer ${accessToken}`;
           return axios(config);
-        } else {
-          // 로그인이 안 된 경우
-          alert("로그인이 필요한 페이지입니다.");
-          navigate("/user/signIn");
         }
+        // else {
+        //   // 로그인이 안 된 경우
+        //   alert("로그인이 필요한 페이지입니다.");
+        //   navigate("/user/signIn");
+        // }
       }
       return Promise.reject(error);
     },

--- a/src/hooks/useAxiosInstance.js
+++ b/src/hooks/useAxiosInstance.js
@@ -71,12 +71,11 @@ function useAxiosInstance() {
 
           config.headers.Authorization = `Bearer ${accessToken}`;
           return axios(config);
+        } else {
+          // 로그인이 안 된 경우
+          alert("로그인이 필요한 페이지입니다.");
+          navigate("/user/signIn");
         }
-        // else {
-        //   // 로그인이 안 된 경우
-        //   alert("로그인이 필요한 페이지입니다.");
-        //   navigate("/user/signIn");
-        // }
       }
       return Promise.reject(error);
     },


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
### 💥 테스트 위치: feat/175-pageRouteRefactoring
- ProtectedRoutes.jsx 파일 추가
- ProtectedRoutes를 추가해서 user가 없다면 signIn으로 이동
- routes.jsx 에 ProtectedRoutes 를 적용해서 로그인 분기 처리
- 라우터 정리

💥 알람 두 번 뜨는 건 toast 적용하고 다시 보기   ----> 배포 후 보기 (strict mode)
💥 알바 내역 페이지 이동시 일부 랜더링 되는거 확인 ----> 해결

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #175
