### PR TITLE
[REFACTOR] 프로필 이미지 삭제 기능 추가

### DIFF
--- a/public/icons/x-box.svg
+++ b/public/icons/x-box.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="11.5" fill="white" stroke="#D9D9D9"/>
+<path d="M5.75 5.75L18.25 18.25" stroke="#FF0000" stroke-width="2"/>
+<path d="M18.25 5.75L5.75 18.25" stroke="#FF0000" stroke-width="2"/>
+</svg>

--- a/src/pages/user/SignUp.jsx
+++ b/src/pages/user/SignUp.jsx
@@ -164,7 +164,10 @@ export default function SignUp() {
         <div className="flex flex-col items-center justify-center">
           <div className="relative inline-block">
             <label htmlFor="image-upload" className="cursor-pointer">
-              <img src={preview} className="w-[150px] h-[150px] mb-3" />
+              <img
+                src={preview}
+                className="w-[150px] h-[150px] mb-3 rounded-full object-fit"
+              />
               <img
                 src="/icons/imgEdit.svg"
                 className="absolute right-2 bottom-2"

--- a/src/pages/user/SignUp.jsx
+++ b/src/pages/user/SignUp.jsx
@@ -62,6 +62,13 @@ export default function SignUp() {
     }
   };
 
+  // 프로필 이미지 삭제
+  const deleteImg = () => {
+    // console.log("delete");
+    setPreview("/images/smiling_daeddamon.png");
+    fileInput.current.value = "";
+  };
+
   // 이메일 중복 체크
   const emailCheck = useMutation({
     mutationFn: email =>
@@ -168,11 +175,16 @@ export default function SignUp() {
                 src={preview}
                 className="w-[150px] h-[150px] mb-3 rounded-full object-fit"
               />
-              <img
+              {/* <img
                 src="/icons/imgEdit.svg"
                 className="absolute right-2 bottom-2"
-              />
+              /> */}
             </label>
+            <img
+              src="/icons/x-box.svg"
+              className="absolute right-3 bottom-3 cursor-pointer w-[30px] h-[30px]"
+              onClick={deleteImg}
+            />
           </div>
 
           <input


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

💥 회원가입 페이지입니다.

✅ "수정 -> 삭제" 로 변경
![image](https://github.com/user-attachments/assets/5d46b306-a70a-4099-b897-b5d2e68a21e7)

프로필 사진을 한 번 등록하면 삭제가 되지 않았는데 수정 버튼을 삭제 버튼으로 변경하였습니다.
(수정 버튼 없앤 이유: 대따몬 누르면 이미지 재지정이 가능해서)

✅ x-box.svg 파일을 추가했습니다. (피그마 추가 완료)
✅ 회원가입 페이지에서 프로필 사진을 추가하면 rounded-full 및 object-fit이 적용이 안되어 있어 추가했습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #206
