### PR TITLE
[Refactor] 홈 페이지 구인 글 리스트 무한 스크롤 

### DIFF
--- a/src/hooks/useGetProducts.js
+++ b/src/hooks/useGetProducts.js
@@ -14,7 +14,9 @@ export const useGetProducts = (keyword, page, limit, select) => {
       );
     },
     select: res => {
-      return select ? select(res.data.item) : res.data.item;
+      const { item } = res.data;
+      const totalCount = res.data.pagination?.total || 0;
+      return select ? select({ item, totalCount }) : { item, totalCount };
     },
     staleTime: 1000 * 10,
     enabled: true,
@@ -35,8 +37,8 @@ export const useProductsFilter = (
     data: fetchedData,
     isLoading,
     refetch,
-  } = useGetProducts(keyword, page, limit, data => {
-    let result = [...data];
+  } = useGetProducts(keyword, page, limit, ({ item, totalCount }) => {
+    let result = [...item];
 
     // 필터 로직
     // wortime
@@ -134,18 +136,18 @@ export const useProductsFilter = (
         });
       }
     }
-    return result;
+    return { item: result, totalCount };
   });
 
   useEffect(() => {
     if (fetchedData) {
-      if (fetchedData.length < limit) {
-        setHasMore(false);
-      }
+      const { item, totalCount } = fetchedData;
+      setHasMore(page * limit < totalCount);
+
       if (page === 1) {
-        setData(fetchedData);
+        setData(item);
       } else {
-        setData(prevData => [...prevData, ...fetchedData]);
+        setData(prevData => [...prevData, ...item]);
       }
     }
   }, [fetchedData, page]);

--- a/src/pages/main/ListItem.jsx
+++ b/src/pages/main/ListItem.jsx
@@ -1,16 +1,14 @@
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { formatDate, getTimePassed, getWorkTime } from "@/utills/func.js";
+import { forwardRef } from "react";
 
-ListItem.propTypes = {
-  data: PropTypes.object.isRequired,
-};
-
-export default function ListItem({ data }) {
+const ListItem = forwardRef(({ data }, ref) => {
   return (
     <Link
       to={`/post/${data._id}`}
       className="flex justify-between shadow-custom-shadow rounded-3xl px-4 py-4 items-center"
+      ref={ref}
     >
       <div className="flex flex-col gap-1 screen-530:gap-[2px] ">
         <h3 className="font-bold text-[1.25rem] screen-530:text-[1rem] break-keep">
@@ -51,4 +49,12 @@ export default function ListItem({ data }) {
       </div>
     </Link>
   );
-}
+});
+
+ListItem.propTypes = {
+  data: PropTypes.object.isRequired,
+};
+
+ListItem.displayName = "ListItem"; // eslint 오류 해결
+
+export default ListItem;

--- a/src/pages/main/PostList.jsx
+++ b/src/pages/main/PostList.jsx
@@ -1,5 +1,6 @@
 import { useProductsFilter } from "@hooks/useGetProducts";
 import ListItem from "@pages/main/ListItem";
+import { useQueryClient } from "@tanstack/react-query";
 import useUserStore from "@zustand/userStore";
 import axios from "axios";
 import { useEffect, useRef, useState } from "react";
@@ -33,7 +34,6 @@ export default function PostList() {
     page,
     limit,
   );
-
   const onWorktimeFilterChanged = e => {
     setCondition(prev => {
       const temp = { ...prev, worktime: e.target.value };
@@ -116,9 +116,7 @@ export default function PostList() {
 
     observerRef.current = new IntersectionObserver(
       entries => {
-        console.log(entries[0].isIntersecting, hasMore, isLoading);
         if (entries[0].isIntersecting && hasMore && !isLoading) {
-          console.log("last item show");
           setPage(prevPage => prevPage + 1);
         }
       },
@@ -127,6 +125,16 @@ export default function PostList() {
 
     if (lastItemRef.current) observerRef.current.observe(lastItemRef.current);
   }, [data, hasMore, isLoading]);
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    setPage(1);
+    queryClient.invalidateQueries({
+      predicate: query => query.queryKey[0] === "products",
+    });
+    refetch();
+  }, [keyword, condition, distanceInfo]);
 
   return (
     <div className="mb-[80px] flex flex-col">

--- a/src/pages/main/PostList.jsx
+++ b/src/pages/main/PostList.jsx
@@ -2,7 +2,7 @@ import { useProductsFilter } from "@hooks/useGetProducts";
 import ListItem from "@pages/main/ListItem";
 import useUserStore from "@zustand/userStore";
 import axios from "axios";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { PulseLoader } from "react-spinners";
@@ -102,6 +102,9 @@ export default function PostList() {
     );
   };
 
+  const lastItemRef = useRef(null);
+
+  console.log(lastItemRef);
   return (
     <div className="mb-[80px] flex flex-col">
       <div className="mb-4 flex justify-between screen-530:flex-wrap">
@@ -208,17 +211,28 @@ export default function PostList() {
         )}
         {data && (
           <>
-            {data.map(data => {
-              // 날짜가 지난 구인글인 경우
-              if (new Date(data.extra.condition.date) < new Date()) return null;
-              // 입금 완료되거나 리뷰가 작성된 구인글인 경우
-              else if (
-                data.extra.state === "EM030" ||
-                data.extra.state === "EM040"
-              )
-                return null;
-              else return <ListItem key={data._id} data={data} />;
-            })}
+            {data
+              .filter(data => {
+                // 날짜가 지난 구인글 제외
+                if (new Date(data.extra.condition.date) < new Date())
+                  return false;
+                // 입금 완료되거나 리뷰가 작성된 구인글 제외
+                if (
+                  data.extra.state === "EM030" ||
+                  data.extra.state === "EM040"
+                )
+                  return false;
+                return true;
+              })
+              .map((data, index, filteredData) => {
+                return (
+                  <ListItem
+                    key={data._id}
+                    data={data}
+                    ref={index === filteredData.length - 1 ? lastItemRef : null}
+                  />
+                );
+              })}
           </>
         )}
       </div>

--- a/src/pages/main/PostList.jsx
+++ b/src/pages/main/PostList.jsx
@@ -113,8 +113,10 @@ export default function PostList() {
 
   useEffect(() => {
     if (observerRef.current) observerRef.current.disconnect();
+
     observerRef.current = new IntersectionObserver(
       entries => {
+        console.log(entries[0].isIntersecting, hasMore, isLoading);
         if (entries[0].isIntersecting && hasMore && !isLoading) {
           console.log("last item show");
           setPage(prevPage => prevPage + 1);


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

홈 게시글에 무한스크롤 적용했습니다. 5개씩 로딩하게 만들었어요.

**테스트 방법**
1. 기본 상태에서 스크롤 확인
2. 5개 상태에서 필터, 검색어 적용 후 스크롤
3. 5개 이상 불러온 상태에서 필터, 검색어 적용

😭원래 게시글을 불러온 후 필터 적용하면 불러온 게시글에도 필터가 적용되게 하려 했는데, 지금 구조에서는 어렵다고 합니다. 

그래서 위에 테스트 방법 3번을 하게 되면 기존 데이터가 사라지고 필터가 적용된 새로운 데이터부터 시작하게 했습니다.  

무한 스크롤 쉽지 않네요 혹시 질문 있으면 주세요

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #224 
